### PR TITLE
paypal-resto-sdk 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "localizr": "~0.1.0",
     "less": "~1.7.0",
     "mongoose": "~3.8.8",
-    "paypal-rest-sdk": "^0.6.4",
+    "paypal-rest-sdk": "^1.5.2",
     "bundalo": "^0.2.4",
     "debuglog": "^1.0.1",
     "localeresolver": "^0.1.1"


### PR DESCRIPTION
Update paypal-rest-sdk version to 1.5.2. Need for work with node.js 0.12.x
