### PR TITLE
Change git clone link from SSH to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kraken with Shopping Cart, universal react view rendering, and PayPal integratio
 Clone, install and run.
 
 ```shell
-git clone git@github.com:krakenjs/kraken-example-with-shoppingcart.git
+git clone https://github.com/krakenjs/kraken-example-with-shoppingcart.git
 cd kraken-example-with-shoppingcart
 npm install
 npm start


### PR DESCRIPTION
Caught this earlier during my internship when messing around with Kraken; not a big deal.

**Using SSH:**
<img width="605" alt="screen shot 2016-07-11 at 10 55 24 am" src="https://cloud.githubusercontent.com/assets/8368618/16740942/0ef79566-4756-11e6-9e1c-5c56b0ee05ff.png">
